### PR TITLE
getglue-java 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Version 1.4.0 *(2014-08-14)*
+--------------------------------
+
+ * Easier customization of `RestAdapter`: set your own HTTP client or executor by overriding `newRestAdapterBuilder()`.
+ * Require `okhttp-urlconnecton`.
+ * Update `okhttp` to 2.0.0 (1.6.0 required at least).
+ * Update `retrofit` to 1.6.1.
+
 Version 1.3.1 *(2014-03-22)*
 --------------------------------
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,20 @@ A Java wrapper around the [v3 API of tvtag (formerly GetGlue)][1] using retrofit
 
 Usage
 =====
+
 Add the following dependency to your Gradle project:
+
 ```
-compile 'com.uwetrottmann:getglue-java:1.3.1'
+compile 'com.uwetrottmann:getglue-java:1.4.0'
 ```
 
 or your Maven project:
+
 ```
 <dependency>
     <groupId>com.uwetrottmann</groupId>
     <artifactId>getglue-java</artifactId>
-    <version>1.3.1</version>
+    <version>1.4.0</version>
 </dependency>
 ```
 
@@ -24,23 +27,31 @@ Dependencies
 
 If you'd rather like to use the [released jar][3], add dependencies yourself as you see fit.
 For example for Gradle:
+
 ```
-compile 'com.squareup.okhttp:okhttp:1.5.4'
-compile 'com.squareup.retrofit:retrofit:1.5.0'
+compile 'com.squareup.okhttp:okhttp:2.0.0'
+compile 'com.squareup.okhttp:okhttp-urlconnection:2.0.0'
+compile 'com.squareup.retrofit:retrofit:1.6.1'
 compile 'org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0'
 ```
 
 Or for Maven:
+
 ```
 <dependency>
   <groupId>com.squareup.okhttp</groupId>
   <artifactId>okhttp</artifactId>
-  <version>1.5.4</version>
+  <version>2.0.0</version>
+</dependency>
+<dependency>
+  <groupId>com.squareup.okhttp</groupId>
+  <artifactId>okhttp-urlconnection</artifactId>
+  <version>2.0.0</version>
 </dependency>
 <dependency>
   <groupId>com.squareup.retrofit</groupId>
   <artifactId>retrofit</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.1</version>
 </dependency>
 <dependency>
     <groupId>org.apache.oltu.oauth2</groupId>
@@ -51,7 +62,9 @@ Or for Maven:
 
 Calling an endpoint
 -------------------
+
 Once you have an access token you can make API calls by using the respective service:
+
 ```
 // You can keep these around
 GetGlue getglue = new GetGlue();
@@ -64,9 +77,11 @@ service.checkin("tv_shows/glee", "This is going to be hilarious.");
 
 Authorization via OAuth
 -----------------------
+
 GetGlue uses OAuth 2.0 to authenticate the apps that use their API.
 First, register your app at the [GetGlue OAuth portal][2] to obtain an OAuth client id and client secret.
 Before using the API the user has to authorize your app so you can get a valid access token.
+
 ```
 OAuthClientRequest request = GetGlue.getAuthorizationRequest(OAUTH_CLIENT_ID, OAUTH_CALLBACK_URL);
 
@@ -79,6 +94,7 @@ String authUrl = request.getLocationUri();
 ```
 
 This auth code can be used once to exchange it for an OAuth access and refresh token.
+
 ```
 OAuthAccessTokenResponse response = GetGlue.getAccessTokenResponse(
                         OAUTH_CLIENT_ID,

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <version>1.4.0</version>
     <packaging>jar</packaging>
 
-    <name>GetGlue Java API Wrapper</name>
+    <name>tvtag Java API Wrapper</name>
     <description>A Java wrapper around the v3 API of tvtag (formerly GetGlue) using retrofit.</description>
     <url>https://github.com/UweTrottmann/getglue-java</url>
     <inceptionYear>2013</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,17 @@
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
-            <version>1.6.0</version>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp-urlconnection</artifactId>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit</groupId>
             <artifactId>retrofit</artifactId>
-            <version>1.5.1</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.oltu.oauth2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.uwetrottmann</groupId>
     <artifactId>getglue-java</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>GetGlue Java API Wrapper</name>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.uwetrottmann</groupId>
     <artifactId>getglue-java</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
 
     <name>GetGlue Java API Wrapper</name>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/uwetrottmann/getglue/GetGlue.java
+++ b/src/main/java/com/uwetrottmann/getglue/GetGlue.java
@@ -19,55 +19,70 @@ import com.uwetrottmann.getglue.client.GetGlueHttpClient;
 import com.uwetrottmann.getglue.services.InteractionService;
 import com.uwetrottmann.getglue.services.ObjectService;
 import com.uwetrottmann.getglue.services.SearchService;
-
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
 import org.apache.oltu.oauth2.client.response.OAuthAccessTokenResponse;
-import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.apache.oltu.oauth2.common.message.types.GrantType;
 import org.apache.oltu.oauth2.common.message.types.ResponseType;
-
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
-import retrofit.client.Client;
-import retrofit.client.OkClient;
 
 public class GetGlue {
 
-    private static final String API_URL = "https://api.getglue.com/v3";
+    public static final String API_URL = "https://api.getglue.com/v3";
 
-    private static final String API_V4_URL = "http://api.getglue.com/v4";
+    public static final String API_V4_URL = "http://api.getglue.com/v4";
 
-    private static final String OAUTH2_AUTHORIZATION_URL
+    public static final String OAUTH2_AUTHORIZATION_URL
             = "https://api.getglue.com/oauth2/authorize";
 
-    private static final String OAUTH2_ACCESS_TOKEN_URL
+    public static final String OAUTH2_ACCESS_TOKEN_URL
             = "https://api.getglue.com/oauth2/access_token";
 
-    private boolean mIsDebug;
+    private boolean isDebug;
+    private String accessToken;
+    private RestAdapter restAdapter;
+    private RestAdapter restAdapterApiFour;
 
-    private String mAccessToken;
-
+    /**
+     * Create a new manager instance. Your next call should probably be {@link #setAccessToken(String)}.
+     */
     public GetGlue() {
     }
 
+    /**
+     * Build an OAuth authorization request.
+     *
+     * @param clientId The OAuth client id obtained from tvtag.
+     * @param redirectUri The URI to redirect to with appended auth code query parameter.
+     * @throws OAuthSystemException
+     */
     public static OAuthClientRequest getAuthorizationRequest(String clientId, String redirectUri)
             throws OAuthSystemException {
-        OAuthClientRequest request = OAuthClientRequest
+        return OAuthClientRequest
                 .authorizationLocation(OAUTH2_AUTHORIZATION_URL)
                 .setScope("public read write")
                 .setResponseType(ResponseType.CODE.toString())
                 .setClientId(clientId)
                 .setRedirectURI(redirectUri)
                 .buildQueryMessage();
-        return request;
     }
 
-    public static OAuthClientRequest getAccessTokenRequest(String clientId, String clientSecret,
-            String redirectUri, String authCode) throws OAuthSystemException {
-        OAuthClientRequest request = OAuthClientRequest
+    /**
+     * Build an OAuth access token request.
+     *
+     * @param clientId The OAuth client id obtained from tvtag.
+     * @param clientSecret The OAuth client secret obtained from tvtag.
+     * @param redirectUri The redirect URI previously used for obtaining the auth code.
+     * @param authCode A previously obtained auth code.
+     * @return A tvtag OAuth access token request.
+     * @throws OAuthSystemException
+     */
+    public static OAuthClientRequest getAccessTokenRequest(String clientId, String clientSecret, String redirectUri,
+            String authCode) throws OAuthSystemException {
+        return OAuthClientRequest
                 .tokenLocation(OAUTH2_ACCESS_TOKEN_URL)
                 .setGrantType(GrantType.AUTHORIZATION_CODE)
                 .setClientId(clientId)
@@ -75,79 +90,130 @@ public class GetGlue {
                 .setRedirectURI(redirectUri)
                 .setCode(authCode)
                 .buildQueryMessage();
-        return request;
     }
 
     /**
-     * Builds a request and executes it, then returns the response which includes the tokens.
+     * Request an access token from tvtag. Builds the request with {@link #getAccessTokenRequest(String, String, String,
+     * String)} and executes it, then returns the response which includes the access and refresh tokens.
+     *
+     * @param clientId The OAuth client id obtained from tvtag.
+     * @param clientSecret The OAuth client secret obtained from tvtag.
+     * @param redirectUri The redirect URI previously used for obtaining the auth code.
+     * @param authCode A previously obtained auth code.
+     * @return A new OAuth access and refresh token from tvtag.
+     * @throws OAuthSystemException
+     * @throws OAuthProblemException
      */
     public static OAuthAccessTokenResponse getAccessTokenResponse(String clientId,
             String clientSecret, String redirectUri, String authCode)
             throws OAuthSystemException, OAuthProblemException {
-        OAuthClientRequest request = getAccessTokenRequest(clientId,
-                clientSecret, redirectUri, authCode);
+        OAuthClientRequest request = getAccessTokenRequest(clientId, clientSecret, redirectUri, authCode);
 
-        // create HTTP client which is able to follow protocol redirects
+        // create HTTP client which is able to follow protocol redirects (tvtag likes to redirect from HTTPS to HTTP)
         OAuthClient client = new OAuthClient(new GetGlueHttpClient());
-        OAuthJSONAccessTokenResponse response = client.accessToken(request);
-        return response;
+        return client.accessToken(request);
     }
 
+    /**
+     * Set the {@link retrofit.RestAdapter} log levels.
+     *
+     * @param isDebug If true, the log level is set to {@link retrofit.RestAdapter.LogLevel#FULL}. Otherwise {@link
+     * retrofit.RestAdapter.LogLevel#NONE}.
+     */
     public GetGlue setIsDebug(boolean isDebug) {
-        mIsDebug = isDebug;
+        this.isDebug = isDebug;
+
+        RestAdapter.LogLevel logLevel = isDebug ? RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.NONE;
+        if (restAdapter != null) {
+            restAdapter.setLogLevel(logLevel);
+        }
+        if (restAdapterApiFour != null) {
+            restAdapterApiFour.setLogLevel(logLevel);
+        }
+
         return this;
     }
 
+    /**
+     * Set a valid OAuth access token for tvtag. Make sure to get new service instances by calling any of the service
+     * methods afterwards.
+     *
+     * @param token A valid OAuth access token.
+     */
     public void setAccessToken(String token) {
-        mAccessToken = token;
+        accessToken = token;
+        restAdapter = null;
     }
 
-    private RestAdapter buildRestAdapter() {
-        RestAdapter.Builder builder = new RestAdapter.Builder()
-                .setEndpoint(API_URL);
+    /**
+     * Create a new {@link retrofit.RestAdapter.Builder}. Override this to e.g. set your own client or executor.
+     *
+     * @return A {@link retrofit.RestAdapter.Builder} with no modifications.
+     */
+    protected RestAdapter.Builder newRestAdapterBuilder() {
+        return new RestAdapter.Builder();
+    }
 
-        builder.setClient(new OkClient(Utils.createOkHttpClient()));
+    /**
+     * Return the current {@link retrofit.RestAdapter} instance. If none exists (first call, access token changed),
+     * builds a new one.
+     *
+     * <p> When building, sets the endpoint, a {@link retrofit.RequestInterceptor} which adds the access token as query
+     * param and the log level.
+     */
+    protected RestAdapter getRestAdapter() {
+        if (restAdapter == null) {
+            RestAdapter.Builder builder = newRestAdapterBuilder();
+            builder.setEndpoint(API_URL);
 
-        // Supply OAuth 2.0 access token
-        builder.setRequestInterceptor(new RequestInterceptor() {
-            @Override
-            public void intercept(RequestFacade request) {
-                request.addQueryParam("access_token", mAccessToken);
+            // Supply OAuth 2.0 access token
+            builder.setRequestInterceptor(new RequestInterceptor() {
+                @Override
+                public void intercept(RequestFacade request) {
+                    request.addQueryParam("access_token", accessToken);
+                }
+            });
+
+            if (isDebug) {
+                builder.setLogLevel(RestAdapter.LogLevel.FULL);
             }
-        });
 
-        if (mIsDebug) {
-            builder.setLogLevel(RestAdapter.LogLevel.FULL);
+            restAdapter = builder.build();
         }
 
-        return builder.build();
+        return restAdapter;
     }
 
-    private RestAdapter buildRestAdapterApiFour() {
-        RestAdapter.Builder builder = new RestAdapter.Builder()
-                .setEndpoint(API_V4_URL);
+    /**
+     * Return the current {@link retrofit.RestAdapter} instance for v4 API calls (currently search only). If none exists
+     * (first call), builds a new one.
+     *
+     * <p> When building, sets the endpoint and log level.
+     */
+    protected RestAdapter getRestAdapterApiFour() {
+        if (restAdapterApiFour == null) {
+            RestAdapter.Builder builder = newRestAdapterBuilder();
+            builder.setEndpoint(API_V4_URL);
 
-        builder.setClient(new OkClient(Utils.createOkHttpClient()));
+            if (isDebug) {
+                builder.setLogLevel(RestAdapter.LogLevel.FULL);
+            }
 
-        if (mIsDebug) {
-            builder.setLogLevel(RestAdapter.LogLevel.FULL);
+            restAdapterApiFour = builder.build();
         }
 
-        return builder.build();
+        return restAdapterApiFour;
     }
 
     public ObjectService objectService() {
-        ObjectService service = buildRestAdapter().create(ObjectService.class);
-        return service;
+        return getRestAdapter().create(ObjectService.class);
     }
 
     public InteractionService interactionService() {
-        InteractionService service = buildRestAdapter().create(InteractionService.class);
-        return service;
+        return getRestAdapter().create(InteractionService.class);
     }
 
     public SearchService searchService() {
-        SearchService service = buildRestAdapterApiFour().create(SearchService.class);
-        return service;
+        return getRestAdapterApiFour().create(SearchService.class);
     }
 }

--- a/src/main/java/com/uwetrottmann/getglue/client/GetGlueHttpClient.java
+++ b/src/main/java/com/uwetrottmann/getglue/client/GetGlueHttpClient.java
@@ -17,6 +17,7 @@
 package com.uwetrottmann.getglue.client;
 
 import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.OkUrlFactory;
 import com.uwetrottmann.getglue.Utils;
 import org.apache.oltu.oauth2.client.HttpClient;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
@@ -47,7 +48,7 @@ public class GetGlueHttpClient implements HttpClient {
         OkHttpClient client = Utils.createOkHttpClient();
 
         try {
-            HttpURLConnection connection = client.open(new URL(request.getLocationUri()));
+            HttpURLConnection connection = new OkUrlFactory(client).open(new URL(request.getLocationUri()));
 
             if (headers != null && !headers.isEmpty()) {
                 for (Map.Entry<String, String> header : headers.entrySet()) {

--- a/src/test/java/com/uwetrottmann/getglue/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/getglue/BaseTestCase.java
@@ -10,7 +10,7 @@ public abstract class BaseTestCase extends TestCase {
 
     protected static final String CLIENT_ID = "7FD930E5C9D030F696ACA631343EB3";
     protected static final String CLIENT_SECRET = "EB4B93F673B95A5A2460CF983BB0A4";
-    private static final String TEMPORARY_ACCESS_TOKEN = "CF604DD9FB0FE147C0CD589C4F0B95";  /* Expires June 21, 2014, 1:13 p.m. */
+    private static final String TEMPORARY_ACCESS_TOKEN = "A86016336417D76D9B632EBB894394";  /* Expires Oct. 13, 2014, 2:32 a.m. */
     protected static final String REDIRECT_URI = "http://localhost";
     private final GetGlue mManager = new GetGlue();
 


### PR DESCRIPTION
- Easier customization of `RestAdapter`: set your own HTTP client or executor by overriding `newRestAdapterBuilder()`.
- Make compatible with okhttp 2.0.0.
